### PR TITLE
Remove white lines from param_name and expression

### DIFF
--- a/addons/blender_godot_pipeline/SceneInit.gd
+++ b/addons/blender_godot_pipeline/SceneInit.gd
@@ -104,8 +104,8 @@ func _set_script_params(node, script_filepath):
 		var line = script_file.get_line()
 		var components = line.split('=')
 		if len(components) > 1:
-			var param_name = components[0]
-			var expression = components[1]
+			var param_name = components[0].rstrip(" ")
+			var expression = components[1].rstrip(" ")
 			
 			var e = Expression.new()
 			e.parse(expression)


### PR DESCRIPTION
White lines causes issues if putting in 'cast_shadow = 3' instead of 'cast_shadow=3' for example. Not sure if intentional for no spaces or not. Seems to work for |'s also. Could break if a stringName or string is passed in that has a space in it