### PR TITLE
Origin fix

### DIFF
--- a/addons/blender_godot_pipeline/SceneInit.gd
+++ b/addons/blender_godot_pipeline/SceneInit.gd
@@ -280,6 +280,14 @@ func _collisions(node, meta_val, metas):
 		cs.scale = node.scale
 		cs.rotation = node.rotation
 		
+		# bump the position by the offset defined
+		if not simple and not trimesh:
+			if "center_x" in metas and "center_y" in metas and "center_z" in metas:
+				var center_x = float(node.get_meta("center_x"))
+				var center_y = float(node.get_meta("center_y"))
+				var center_z = float(node.get_meta("center_z"))
+				cs.position += Vector3(center_x, center_y, center_z)
+		
 		if "box" in meta_val:
 			if "size_x" in metas and "size_x" in metas \
 			and "size_z" in metas:

--- a/addons/blender_godot_pipeline/SceneInit.gd
+++ b/addons/blender_godot_pipeline/SceneInit.gd
@@ -286,7 +286,7 @@ func _collisions(node, meta_val, metas):
 				var center_x = float(node.get_meta("center_x"))
 				var center_y = float(node.get_meta("center_y"))
 				var center_z = float(node.get_meta("center_z"))
-				cs.position += Vector3(center_x, center_y, center_z)
+				cs.position = Vector3(center_x, center_y, center_z)
 		
 		if "box" in meta_val:
 			if "size_x" in metas and "size_x" in metas \


### PR DESCRIPTION
this commit allows collision shapes to maintain their origin position, while still getting intelligent primitive collision shapes from Blender